### PR TITLE
Define redis connection string as URL.

### DIFF
--- a/queues/backends/redisd.py
+++ b/queues/backends/redisd.py
@@ -40,7 +40,7 @@ password = redis_url.password
 port = redis_url.port
 
 if not host:
-    raise InvalidBackend("REDIS_URL is missing host (url format should be redis://:password@hostname:port/db_number).")
+    raise InvalidBackend("REDIS_URL is missing host (url format should be redis://username:password@hostname:port/db_number).")
 
 try:
     port = int(port)

--- a/queues/backends/redisd.py
+++ b/queues/backends/redisd.py
@@ -48,7 +48,7 @@ except ValueError:
     raise InvalidBackend("Port portion of REDIS_URL should be an integer.")
 
 
-def _get_connection(host=host, port=port, db=DB, password=None, timeout=TIMEOUT):
+def _get_connection(host=host, port=port, db=DB, password=password, timeout=TIMEOUT):
     kwargs = {'host' : host, 'port' : port}
     if DB:
         kwargs['db'] = DB


### PR DESCRIPTION
There's a silly limitation in the `queues` library. It creates a connection using the python `redis` package but doesn't pass a password arg!
See: https://github.com/suicidegirlsdev/queues/blob/master/queues/backends/redisd.py#L51

This PR updates the redis backend to get the host, port, password, and DB # from a redis URL config var. 

It's a dependency for https://github.com/suicidegirlsdev/suicidegirls/pull/961
